### PR TITLE
Set the working dir and shadow file flag for mypy

### DIFF
--- a/src/checkers/flymake-collection-mypy.el
+++ b/src/checkers/flymake-collection-mypy.el
@@ -111,6 +111,8 @@ See URL `http://mypy-lang.org/'."
                     "--shadow-file" source-file flymake-collection-temp-file
                     source-file)
                  (list flymake-collection-temp-file)))
+  ;; Temporary file cannot start with a dot for mypy, see
+  ;; https://github.com/mohkale/flymake-collection/pull/9
   :temp-file-prefix "flymake_mypy_"
   :regexps
   ((error   bol (file-name) ":" line ":" column ": error: "

--- a/src/checkers/flymake-collection-mypy.el
+++ b/src/checkers/flymake-collection-mypy.el
@@ -26,6 +26,7 @@
 
 ;;; Code:
 
+(require 'project)
 (require 'flymake)
 (require 'flymake-collection)
 

--- a/src/checkers/flymake-collection-mypy.el
+++ b/src/checkers/flymake-collection-mypy.el
@@ -113,11 +113,11 @@ See URL `http://mypy-lang.org/'."
                  (list flymake-collection-temp-file)))
   :regexps
   ((error   bol (file-name) ":" line ":" column ": error: "
-            (message) (opt "  [" (id (one-or-more alpha)) "]") eol)
+            (message) (opt "  [" (id (* graph)) "]") eol)
    (warning bol (file-name) ":" line ":" column ": warning: "
-            (message) (opt "  [" (id (one-or-more alpha)) "]") eol)
+            (message) (opt "  [" (id (* graph)) "]") eol)
    (note    bol (file-name) ":" line ":" column ": note: "
-            (message) (opt "  [" (id (one-or-more alpha)) "]") eol)))
+            (message) (opt "  [" (id (* graph)) "]") eol)))
 
 (provide 'flymake-collection-mypy)
 

--- a/src/checkers/flymake-collection-mypy.el
+++ b/src/checkers/flymake-collection-mypy.el
@@ -34,11 +34,7 @@
   (require 'flymake-collection-define))
 
 (defcustom flymake-collection-mypy-args
-  '("--show-column-numbers"
-    "--no-error-summary"
-    "--no-color-output"
-    "--show-absolute-path"
-    "--show-error-codes")
+  '("--show-error-codes")
   "Command line arguments always passed to `flymake-collection-mypy'."
   :type '(repeat (string :tag "Arg"))
   :group 'flymake-collection)
@@ -103,6 +99,10 @@ See URL `http://mypy-lang.org/'."
   :write-type 'file
   :source-inplace t
   :command `(,mypy-exec
+             "--show-column-numbers"
+             "--show-absolute-path"
+             "--no-error-summary"
+             "--no-color-output"
              ,@flymake-collection-mypy-args
              ,@(if-let ((source-file (buffer-file-name
                                       flymake-collection-source))

--- a/src/checkers/flymake-collection-mypy.el
+++ b/src/checkers/flymake-collection-mypy.el
@@ -111,6 +111,7 @@ See URL `http://mypy-lang.org/'."
                     "--shadow-file" source-file flymake-collection-temp-file
                     source-file)
                  (list flymake-collection-temp-file)))
+  :temp-file-prefix "flymake_mypy_"
   :regexps
   ((error   bol (file-name) ":" line ":" column ": error: "
             (message) (opt "  [" (id (* graph)) "]") eol)

--- a/src/checkers/flymake-collection-mypy.el
+++ b/src/checkers/flymake-collection-mypy.el
@@ -84,9 +84,12 @@ See URL `http://mypy-lang.org/'."
                     source-file)
                  (list flymake-collection-temp-file)))
   :regexps
-  ((error   bol (file-name) ":" line ":" column ": error: "   (message) eol)
-   (warning bol (file-name) ":" line ":" column ": warning: " (message) eol)
-   (note    bol (file-name) ":" line ":" column ": note: "    (message) eol)))
+  ((error   bol (file-name) ":" line ":" column ": error: "
+            (message) "  [" (id (one-or-more not-newline)) "]" eol)
+   (warning bol (file-name) ":" line ":" column ": warning: "
+            (message) "  [" (id (one-or-more not-newline)) "]" eol)
+   (note    bol (file-name) ":" line ":" column ": note: "
+            (message) "  [" (id (one-or-more not-newline)) "]" eol)))
 
 (provide 'flymake-collection-mypy)
 

--- a/src/flymake-collection-define.el
+++ b/src/flymake-collection-define.el
@@ -84,7 +84,7 @@ doesn't exist: %s" dir))
      (let ((temporary-file-directory ,temp-dir)
            (basename (file-name-nondirectory (or (buffer-file-name)
                                                  (buffer-name)))))
-       (make-temp-file ".flymake_" nil (concat "_" basename))))))
+       (make-temp-file "flymake_" nil (concat "_" basename))))))
 
 (defmacro flymake-collection-define--parse-diags
     (title proc-symb diags-symb current-diag-symb source-symb error-parser)

--- a/tests/checkers/installers/mypy.bash
+++ b/tests/checkers/installers/mypy.bash
@@ -1,0 +1,1 @@
+python3.8 -m pip install mypy

--- a/tests/checkers/test-cases/mypy.yml
+++ b/tests/checkers/test-cases/mypy.yml
@@ -16,6 +16,16 @@ tests:
       - point: [3, 6]
         level: error
         message: operator Unsupported operand types for + ("str" and "int") (mypy)
+  - name: error-attr-defined
+    file: |
+      """Test parsing an error with a hyphen in the id."""
+
+      x = 1
+      x.foo
+    lints:
+      - point: [4, 0]
+        level: error
+        message: attr-defined "int" has no attribute "foo" (mypy)
   - name: note-reveal
     file: |
       """Test parsing a note."""

--- a/tests/checkers/test-cases/mypy.yml
+++ b/tests/checkers/test-cases/mypy.yml
@@ -1,0 +1,37 @@
+---
+checker: flymake-collection-mypy
+tests:
+  - name: no-lints
+    file: |
+      """A test case with no output from mypy."""
+
+      print("hello world")
+    lints: []
+  - name: error-operator
+    file: |
+      """Test parsing an error."""
+
+      "x" + 1
+    lints:
+      - point: [3, 6]
+        level: error
+        message: operator Unsupported operand types for + ("str" and "int") (mypy)
+  - name: note-reveal
+    file: |
+      """Test parsing a note."""
+
+      foo = "bar"
+      reveal_type(foo)
+    lints:
+      - point: [4, 12]
+        level: note
+        message: Revealed type is "builtins.str" (mypy)
+  - name: error-syntax
+    file: |
+      """Test syntax error."""
+
+      class Foo:
+    lints:
+      - point: [3, 0]
+        level: error
+        message: syntax unexpected EOF while parsing (mypy)


### PR DESCRIPTION
Mypy requires some configuration in most cases, which it looks for in its working directory by default. You can check that `flymake-collection-mypy` won't work with projects like urllib3 at the moment. This updates `flymake-collection-mypy` to set `default-directory` to a parent dir containing a config file, if it exists. It also adds the `mypy --shadow-file` flag to make sure types are defined in the right module and caching works when processing temp files. Also includes minor tweaks to make flags customizable and parse out the diagnostic id.

Some things to consider:
- Making setting the cwd opt-in, if it's important to preserve the current behavior
- Adding a separate `:working-dir` keyword arg like flycheck instead of using `:pre-let`
- I had to remove the leading dot from temp files, which appears to break relative imports. This will affect all checkers, but it could be made configurable per-checker