### PR TITLE
Additional checkers

### DIFF
--- a/src/checkers/flymake-collection-bandit.el
+++ b/src/checkers/flymake-collection-bandit.el
@@ -1,0 +1,51 @@
+;;; flymake-collection-bandit.el --- bandit diagnostic function -*- lexical-binding: t -*-
+
+;; Copyright (c) 2024 Abdelhak Bougouffa
+
+;; Permission is hereby granted, free of charge, to any person obtaining a copy
+;; of this software and associated documentation files (the "Software"), to deal
+;; in the Software without restriction, including without limitation the rights
+;; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+;; copies of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+
+;; The above copyright notice and this permission notice shall be included in all
+;; copies or substantial portions of the Software.
+
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+;; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+;; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+;;; Commentary:
+
+;; `flymake' checker for common security issues in Python code using "bandit".
+
+;;; Code:
+
+(require 'flymake)
+(require 'flymake-collection)
+
+(eval-when-compile
+  (require 'flymake-collection-define))
+
+;;;###autoload (autoload 'flymake-collection-bandit "flymake-collection-bandit")
+(flymake-collection-define-rx flymake-collection-bandit
+  "Find common security issues in Python code."
+  :title "bandit"
+  :pre-let ((bandit-exec (executable-find "bandit")))
+  :pre-check (unless bandit-exec (error "Cannot find bandit executable"))
+  :write-type 'file
+  :command (list bandit-exec "--format" "custom" "--msg-template" "diag:{line}:{severity}:{test_id}: {msg}" flymake-collection-temp-file)
+  :regexps
+  ((error   bol "diag:" line ":" "HIGH" ":" (id (* alnum)) ":" (message) eol)
+   (warning bol "diag:" line ":" "MEDIUM" ":" (id (* alnum)) ":" (message) eol)
+   (note    bol "diag:" line ":" (or "LOW" "UNDEFINED") ":" (id (* alnum)) ":" (message) eol)))
+
+
+(provide 'flymake-collection-bandit)
+
+;;; flymake-collection-bandit.el ends here

--- a/src/checkers/flymake-collection-clang-tidy.el
+++ b/src/checkers/flymake-collection-clang-tidy.el
@@ -47,7 +47,7 @@
 
 ;;; Helpers
 
-(defun flymake-clang-tidy-find-project-root (_checker)
+(defun flymake-collection-clang-tidy-find-project-root (_checker)
   "Find the project root for CHECKER.
 This uses `project', `projectile', `vc' or the \".clang-tidy\" file"
   (or
@@ -62,8 +62,8 @@ This uses `project', `projectile', `vc' or the \".clang-tidy\" file"
 
 (defun flymake-collection-clang-tidy-get-config ()
   "Find and read .clang-tidy."
-  (when-let* ((config-dir (locate-dominating-file (or buffer-file-name default-directory) ".clang-tidy"))
-              (config-file (expand-file-name ".clang-tidy" config-dir)))
+  (when-let ((config-dir (locate-dominating-file (or buffer-file-name default-directory) ".clang-tidy"))
+             (config-file (expand-file-name ".clang-tidy" config-dir)))
     (with-temp-buffer
       (insert-file-contents config-file)
       (buffer-string))))

--- a/src/checkers/flymake-collection-clang-tidy.el
+++ b/src/checkers/flymake-collection-clang-tidy.el
@@ -1,0 +1,92 @@
+;;; flymake-collection-clang-tidy.el --- Clang-tidy diagnostic function -*- lexical-binding: t -*-
+
+;; Copyright (c) 2024 Abdelhak Bougouffa
+
+;; Permission is hereby granted, free of charge, to any person obtaining a copy
+;; of this software and associated documentation files (the "Software"), to deal
+;; in the Software without restriction, including without limitation the rights
+;; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+;; copies of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+
+;; The above copyright notice and this permission notice shall be included in all
+;; copies or substantial portions of the Software.
+
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+;; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+;; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+;;; Commentary:
+
+;; `flymake' static checker for C/C++ using "clang-tidy".
+;; Inspired by `flycheck-clang-tidy' - https://github.com/ch1bo/flycheck-clang-tidy
+
+;;; Code:
+
+(require 'flymake)
+(require 'flymake-collection)
+
+(eval-when-compile
+  (require 'flymake-collection-define))
+
+;;; Custom variables
+
+(defcustom flymake-collection-clang-tidy-build-path "build"
+  "Clang build directory."
+  :type '(choice (const nil) directory)
+  :group 'flymake-collection)
+
+(defcustom flymake-collection-clang-tidy-extra-options nil
+  "Extra options to pass to Clang-tidy."
+  :type '(choice (const nil) (repeat string))
+  :group 'flymake-collection)
+
+;;; Helpers
+
+(defun flymake-clang-tidy-find-project-root (_checker)
+  "Find the project root for CHECKER.
+This uses `project', `projectile', `vc' or the \".clang-tidy\" file"
+  (or
+   (when (and (bound-and-true-p projectile-mode) (fboundp 'projectile-project-root))
+     (projectile-project-root))
+   (and (project-current) (project-root (project-current)))
+   (vc-root-dir)
+   (locate-dominating-file (or buffer-file-name default-directory) ".clang-tidy")
+   (progn
+     (message "Could not determine project root, trying current directory.")
+     (file-name-directory buffer-file-name))))
+
+(defun flymake-collection-clang-tidy-get-config ()
+  "Find and read .clang-tidy."
+  (when-let* ((config-dir (locate-dominating-file (or buffer-file-name default-directory) ".clang-tidy"))
+              (config-file (expand-file-name ".clang-tidy" config-dir)))
+    (with-temp-buffer
+      (insert-file-contents config-file)
+      (buffer-string))))
+
+;;;###autoload (autoload 'flymake-collection-clang-tidy "flymake-collection-clang-tidy")
+(flymake-collection-define-rx flymake-collection-clang-tidy
+  "Clang-based C++ linter tool."
+  :pre-let ((clang-tidy-exec (executable-find "clang-tidy")))
+  :pre-check (unless clang-tidy-exec (error "Cannot find clang-tidy executable"))
+  :write-type 'file
+  :command (append
+            (list clang-tidy-exec)
+            (when flymake-collection-clang-tidy-build-path (list "-p" flymake-collection-clang-tidy-build-path))
+            (when buffer-file-name (list (concat "-extra-arg=-I" (file-name-directory buffer-file-name))))
+            (when (flymake-collection-clang-tidy-get-config) (list (concat "-config=" (flymake-collection-clang-tidy-get-config))))
+            (ensure-list flymake-collection-clang-tidy-extra-options)
+            (list flymake-collection-temp-file))
+  :regexps
+  ((error bol (file-name) ":" line ":" column ": error:" (message) eol)
+   (warning bol (file-name) ":" line ":" column ": warning:" (message) eol)
+   (note bol (file-name) ":" line ":" column ": note:" (message) eol)))
+
+
+(provide 'flymake-collection-clang-tidy)
+
+;;; flymake-collection-clang-tidy.el ends here

--- a/src/checkers/flymake-collection-codespell.el
+++ b/src/checkers/flymake-collection-codespell.el
@@ -1,0 +1,50 @@
+;;; flymake-collection-codespell.el --- codespell diagnostic function -*- lexical-binding: t -*-
+
+;; Copyright (c) 2024 Abdelhak Bougouffa
+
+;; Permission is hereby granted, free of charge, to any person obtaining a copy
+;; of this software and associated documentation files (the "Software"), to deal
+;; in the Software without restriction, including without limitation the rights
+;; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+;; copies of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+
+;; The above copyright notice and this permission notice shall be included in all
+;; copies or substantial portions of the Software.
+
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+;; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+;; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+;;; Commentary:
+
+;; `flymake' checker for common misspellings in code using "codespell".
+
+;;; Code:
+
+(require 'flymake)
+(require 'flymake-collection)
+
+(eval-when-compile
+  (require 'flymake-collection-define))
+
+
+;;;###autoload (autoload 'flymake-collection-codespell "flymake-collection-codespell")
+(flymake-collection-define-rx flymake-collection-codespell
+  "Check code for common misspellings."
+  :title "codespell"
+  :pre-let ((codespell-exec (executable-find "codespell")))
+  :pre-check (unless codespell-exec (error "Cannot find codespell executable"))
+  :write-type 'file
+  :command (list codespell-exec "-d" "-i0" flymake-collection-temp-file)
+  :regexps
+  ((warning bol (file-name) ":" line ": " (message) eol)))
+
+
+(provide 'flymake-collection-codespell)
+
+;;; flymake-collection-codespell.el ends here

--- a/src/checkers/flymake-collection-nasm.el
+++ b/src/checkers/flymake-collection-nasm.el
@@ -1,0 +1,58 @@
+;;; flymake-collection-nasm.el --- NASM diagnostic function -*- lexical-binding: t -*-
+
+;; Copyright (c) 2024 Abdelhak Bougouffa
+
+;; Permission is hereby granted, free of charge, to any person obtaining a copy
+;; of this software and associated documentation files (the "Software"), to deal
+;; in the Software without restriction, including without limitation the rights
+;; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+;; copies of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+
+;; The above copyright notice and this permission notice shall be included in all
+;; copies or substantial portions of the Software.
+
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+;; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+;; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+;;; Commentary:
+
+;; `flymake' checker for Assembly using "nasm".
+;; Inspired by `flymake-nasm' - https://github.com/juergenhoetzel/flymake-nasm
+
+;;; Code:
+
+(require 'flymake)
+(require 'flymake-collection)
+
+(eval-when-compile
+  (require 'flymake-collection-define))
+
+(defcustom flymake-collection-nasm-format 'elf64
+  "The NASM output format.
+You can list the supported formats by running \"nasm -hf\"q."
+  :type 'symbol
+  :group 'flymake-collection)
+
+;;;###autoload (autoload 'flymake-collection-nasm "flymake-collection-nasm")
+(flymake-collection-define-rx flymake-collection-nasm
+  "Assembly checker using the Netwide Assembler (NASM)."
+  :title "nasm"
+  :pre-let ((nasm-exec (executable-find "nasm")))
+  :pre-check (unless nasm-exec (error "Not found nasm on PATH"))
+  :write-type 'file
+  :command `(,nasm-exec ,(format "-f%s" flymake-collection-nasm-format) ,flymake-collection-temp-file)
+  :regexps
+  ((error bol (file-name) ":" line ": error: " (message) eol)
+   (warning bol (file-name) ":" line ": warning: " (message) eol)
+   (note bol (file-name) ":" line ": note: " (message) eol)))
+
+
+(provide 'flymake-collection-nasm)
+
+;;; flymake-collection-nasm.el ends here

--- a/src/checkers/flymake-collection-pyre.el
+++ b/src/checkers/flymake-collection-pyre.el
@@ -1,0 +1,50 @@
+;;; flymake-collection-pyre.el --- pyre diagnostic function -*- lexical-binding: t -*-
+
+;; Copyright (c) 2024 Abdelhak Bougouffa
+
+;; Permission is hereby granted, free of charge, to any person obtaining a copy
+;; of this software and associated documentation files (the "Software"), to deal
+;; in the Software without restriction, including without limitation the rights
+;; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+;; copies of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+
+;; The above copyright notice and this permission notice shall be included in all
+;; copies or substantial portions of the Software.
+
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+;; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+;; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+;;; Commentary:
+
+;; `flymake' type-checker for Python 3 using "pyre".
+
+;;; Code:
+
+(require 'flymake)
+(require 'flymake-collection)
+
+(eval-when-compile
+  (require 'flymake-collection-define))
+
+
+;;;###autoload (autoload 'flymake-collection-pyre "flymake-collection-pyre")
+(flymake-collection-define-rx flymake-collection-pyre
+  "Performant type-checking for python."
+  :title "pyre"
+  :pre-let ((pyre-exec (executable-find "pyre")))
+  :pre-check (unless pyre-exec (error "Cannot find pyre in PATH"))
+  :write-type 'file
+  :command `(,pyre-exec)
+  :regexps
+  ((warning bol (file-name) ":" line ":" column " " (message) eol)))
+
+
+(provide 'flymake-collection-pyre)
+
+;;; flymake-collection-pyre.el ends here

--- a/src/flymake-collection-hook.el
+++ b/src/flymake-collection-hook.el
@@ -53,6 +53,7 @@
       (flymake-collection-flake8 :disabled t)
       (flymake-collection-ruff :disabled t)))
     (awk-mode . (flymake-collection-awk-gawk))
+    ((asm-mode nasm-mode) . (flymake-collection-nasm))
     ((c-mode c-ts-mode) .
      (flymake-collection-clang
       (flymake-collection-codespell :disabled t)

--- a/src/flymake-collection-hook.el
+++ b/src/flymake-collection-hook.el
@@ -49,6 +49,7 @@
       (flymake-mypy :disabled t)
       (flymake-collection-bandit :disabled t)
       (flymake-collection-codespell :disabled t)
+      (flymake-collection-pyre :disabled t)
       (flymake-collection-pylint :disabled t)
       (flymake-collection-flake8 :disabled t)
       (flymake-collection-ruff :disabled t)))

--- a/src/flymake-collection-hook.el
+++ b/src/flymake-collection-hook.el
@@ -58,10 +58,12 @@
     ((c-mode c-ts-mode) .
      (flymake-collection-clang
       (flymake-collection-codespell :disabled t)
+      (flymake-collection-clang-tidy :disabled t)
       (flymake-collection-gcc :disabled t)))
     ((c++-mode c++-ts-mode) .
      (flymake-collection-clang
       (flymake-collection-codespell :disabled t)
+      (flymake-collection-clang-tidy :disabled t)
       (flymake-collection-gcc :disabled t)))
     (haskell-mode . (flymake-collection-hlint))
     ((janet-mode janet-ts-mode) . (flymake-collection-janet))

--- a/src/flymake-collection-hook.el
+++ b/src/flymake-collection-hook.el
@@ -47,6 +47,7 @@
      (flymake-collection-pycodestyle
       (python-flymake :disabled t)
       (flymake-mypy :disabled t)
+      (flymake-collection-bandit :disabled t)
       (flymake-collection-codespell :disabled t)
       (flymake-collection-pylint :disabled t)
       (flymake-collection-flake8 :disabled t)

--- a/src/flymake-collection-hook.el
+++ b/src/flymake-collection-hook.el
@@ -39,29 +39,35 @@
 
 ;;;###autoload
 (defcustom flymake-collection-hook-config
-  '((elisp-mode .
+  '((emacs-lisp-mode .
      (elisp-flymake-byte-compile
-      elisp-flymake-checkdoc))
+      elisp-flymake-checkdoc
+      (flymake-collection-codespell :disabled t)))
     ((python-mode python-ts-mode) .
      (flymake-collection-pycodestyle
       (python-flymake :disabled t)
       (flymake-mypy :disabled t)
+      (flymake-collection-codespell :disabled t)
       (flymake-collection-pylint :disabled t)
       (flymake-collection-flake8 :disabled t)
       (flymake-collection-ruff :disabled t)))
     (awk-mode . (flymake-collection-awk-gawk))
     ((c-mode c-ts-mode) .
      (flymake-collection-clang
+      (flymake-collection-codespell :disabled t)
       (flymake-collection-gcc :disabled t)))
     ((c++-mode c++-ts-mode) .
      (flymake-collection-clang
+      (flymake-collection-codespell :disabled t)
       (flymake-collection-gcc :disabled t)))
     (haskell-mode . (flymake-collection-hlint))
     ((janet-mode janet-ts-mode) . (flymake-collection-janet))
     ((js-mode js2-mode typescript-mode typescript-ts-mode) .
-     (flymake-collection-eslint))
+     (flymake-collection-eslint
+      (flymake-collection-codespell :disabled t)))
     ((json-mode json-ts-mode) .
      (flymake-collection-jq
+      (flymake-collection-codespell :disabled t)
       (flymake-collection-jsonlint :disabled t)))
     (less-mode flymake-collection-less)
     (markdown-mode
@@ -77,13 +83,16 @@
      flymake-collection-sql-lint
      (flymake-collection-sqlint :disabled t))
     ((ruby-mode ruby-ts-mode) .
-     (flymake-collection-rubocop))
+     (flymake-collection-rubocop
+      (flymake-collection-codespell :disabled t)))
     ;; (hledger-mode flymake-collection-hledger)
     ((sh-mode bash-ts-mode) .
      (flymake-collection-shellcheck
+      (flymake-collection-codespell :disabled t)
       (sh-shellcheck-flymake :disabled t)))
     ((yaml-mode yaml-ts-mode) .
      (flymake-collection-yamllint
+      (flymake-collection-codespell :disabled t)
       (flymake-collection-kube-linter :disabled t)))
     ((web-mode html-ts-mode) .
      (flymake-collection-html-tidy))

--- a/tests/checkers/installers/bandit.bash
+++ b/tests/checkers/installers/bandit.bash
@@ -1,0 +1,1 @@
+python3 -m pip install bandit

--- a/tests/checkers/installers/clang-tidy.bash
+++ b/tests/checkers/installers/clang-tidy.bash
@@ -1,0 +1,1 @@
+apt-get install -y clang-tidy

--- a/tests/checkers/installers/codespell.bash
+++ b/tests/checkers/installers/codespell.bash
@@ -1,0 +1,1 @@
+python3 -m pip install codespell

--- a/tests/checkers/installers/nasm.bash
+++ b/tests/checkers/installers/nasm.bash
@@ -1,0 +1,1 @@
+apt-get install -y nasm

--- a/tests/checkers/installers/pyre.bash
+++ b/tests/checkers/installers/pyre.bash
@@ -1,0 +1,1 @@
+python3 -m pip install pyre-check

--- a/tests/checkers/test-cases/bandit.yml
+++ b/tests/checkers/test-cases/bandit.yml
@@ -1,0 +1,33 @@
+---
+checker: flymake-collection-bandit
+tests:
+  - name: no-lints
+    file: |
+      """A test case with no output from bandit."""
+
+      print("hello world")
+    lints: []
+  - name: hardcoded-password
+    file: |
+      """A test case with an output from bandit"""
+
+      class SomeClass:
+          password = "class_password"
+
+    lints:
+      - point: [4, 4]
+        level: note
+        message: "B105  Possible hardcoded password: 'class_password' (bandit)"
+  - name: ciphers
+    file: |
+      """A test case with an output from codespell"""
+
+      from cryptography.hazmat.primitives.ciphers.modes import ECB
+
+      # Insecure mode
+      mode = ECB(iv)
+
+    lints:
+      - point: [6, 0]
+        level: warning
+        message: "B305  Use of insecure cipher mode cryptography.hazmat.primitives.ciphers.modes.ECB. (bandit)"

--- a/tests/checkers/test-cases/codespell.yml
+++ b/tests/checkers/test-cases/codespell.yml
@@ -1,0 +1,18 @@
+---
+checker: flymake-collection-codespell
+tests:
+  - name: no-lints
+    file: |
+      """A test case with no output from codespell."""
+
+      print("hello world")
+    lints: []
+  - name: misspelling
+    file: |
+      """A test case with an output from codespell"""
+
+      vairable = "Hello"
+    lints:
+      - point: [3, 0]
+        level: warning
+        message: vairable ==> variable (codespell)

--- a/tests/checkers/test-cases/nasm.yml
+++ b/tests/checkers/test-cases/nasm.yml
@@ -22,7 +22,7 @@ tests:
     lints:
       - point: [4, 4]
         level: error
-        message: "symbol `message' not defined (nasm)"
+        message: "symbol `message' undefined (nasm)" # TODO: "undefined" becomes "not defined" in newer NASM version
       - point: [8, 4]
         level: error
-        message: "symbol `raxx' not defined (nasm)"
+        message: "symbol `raxx' undefined (nasm)" # TODO: "undefined" becomes "not defined" in newer NASM version

--- a/tests/checkers/test-cases/nasm.yml
+++ b/tests/checkers/test-cases/nasm.yml
@@ -1,0 +1,28 @@
+---
+checker: flymake-collection-nasm
+tests:
+  - name: no-lints
+    file: |
+      _start:
+          mov     rax, 1
+          mov     rdi, 1
+    lints: []
+  - name: errors
+    file: |
+      _start:
+          mov     rax, 1
+          mov     rdi, 1
+          mov     rsi, message
+          mov     rdx, 14
+
+          syscall
+          mov     raxx, 60
+          xor     rdi, rdi
+          syscall
+    lints:
+      - point: [4, 4]
+        level: error
+        message: "symbol `message' not defined (nasm)"
+      - point: [8, 4]
+        level: error
+        message: "symbol `raxx' not defined (nasm)"


### PR DESCRIPTION
First, I would like to thank you for this collection!

I've been using `flymake-collection` to define some checkers in my config for tools that I use regularly. And I thought I should contribute them back!

This PR include checkers for:

- [bandit](https://github.com/PyCQA/bandit)
- [codespell](https://github.com/codespell-project/codespell)
- [pyre](https://github.com/facebook/pyre-check)
- [clang-tidy](https://clang.llvm.org/extra/clang-tidy/)
- [nasm](https://github.com/netwide-assembler/nasm)

I've tried to add the install commands and some tests, but I'm kind of trying blindly because I didn't manage to run the Docker used to run tests!

### Edit
A little bug fix slipped into one of the commits, the setup hook for Elisp was wrongly set to `elisp-mode` instead of `emacs-lisp-mode`.