### PR TITLE
Add Bashate style checker for Bash scripts

### DIFF
--- a/src/checkers/flymake-collection-bashate.el
+++ b/src/checkers/flymake-collection-bashate.el
@@ -1,0 +1,52 @@
+;;; flymake-collection-bashate.el --- Bashate diagnostic function -*- lexical-binding: t -*-
+
+;; Copyright (C) 2024 James Cherti | https://www.jamescherti.com/contact/
+
+;; Permission is hereby granted, free of charge, to any person obtaining a copy
+;; of this software and associated documentation files (the "Software"), to deal
+;; in the Software without restriction, including without limitation the rights
+;; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+;; copies of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+
+;; The above copyright notice and this permission notice shall be included in all
+;; copies or substantial portions of the Software.
+
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+;; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+;; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+;;; Commentary:
+
+;; `flymake' style checker for bash scripts using bashate.
+
+;;; Code:
+
+(require 'flymake)
+(require 'flymake-collection)
+
+(eval-when-compile
+  (require 'flymake-collection-define))
+
+;;;###autoload (autoload 'flymake-collection-bashate "flymake-collection-bashate")
+(flymake-collection-define-rx flymake-collection-bashate
+  "A Bash style checker using bashate.
+See URL `https://github.com/openstack/bashate`."
+  :title "bashate"
+  :pre-let ((bashate-exec (executable-find "bashate")))
+  :pre-check (unless bashate-exec
+               (error "The bashate executable was not found"))
+  :write-type 'file
+  :command `(,bashate-exec
+             ,flymake-collection-temp-file)
+  :regexps
+  ((error bol (file-name) ":" line ":" column
+          ": " (id (one-or-more alnum)) " " (message) eol)))
+
+(provide 'flymake-collection-bashate)
+
+;;; flymake-collection-bashate.el ends here

--- a/src/flymake-collection-hook.el
+++ b/src/flymake-collection-hook.el
@@ -79,8 +79,9 @@
      (flymake-collection-rubocop))
     ;; (hledger-mode flymake-collection-hledger)
     ((sh-mode bash-ts-mode) .
-     (flymake-collection-shellcheck
-      (sh-shellcheck-flymake :disabled t)))
+     (flymake-collection-bashate
+      (flymake-collection-shellcheck
+      (sh-shellcheck-flymake :disabled t))))
     ((yaml-mode yaml-ts-mode) .
      (flymake-collection-yamllint
       (flymake-collection-kube-linter :disabled t)))

--- a/tests/checkers/installers/bashate.bash
+++ b/tests/checkers/installers/bashate.bash
@@ -1,0 +1,1 @@
+python3.8 -m pip install bashate

--- a/tests/checkers/test-cases/bashate.yml
+++ b/tests/checkers/test-cases/bashate.yml
@@ -1,0 +1,18 @@
+---
+checker: flymake-collection-bashate
+tests:
+  - name: no-lints
+    file: |
+      # A test case with no output from bashate.
+      echo "hello world"
+    lints: []
+  - name: test
+    file: |
+      # A test case with a warning lint.
+      if true; then
+                echo "Hello world"
+      fi
+    lints:
+      - point: [3, 1]
+        level: error
+        message: "test-lint.sh:3:1: E003 Indent not multiple of 4"


### PR DESCRIPTION
This pull request adds the bashate style checker to flymake-collection, an automated tool specifically designed to enforce consistent coding standards in Bash scripts. It is similar to how pep8 serves Python projects by ensuring code adheres to style guidelines, bashate analyzes Bash scripts to detect potential style issues, promoting readability, maintainability, and adherence to best practices.