### PR TITLE
add checker: perlcritic

### DIFF
--- a/src/checkers/flymake-collection-perlcritic.el
+++ b/src/checkers/flymake-collection-perlcritic.el
@@ -1,0 +1,80 @@
+;;; flymake-collection-perlcritic.el --- perl diagnostic function using perlcritic -*- lexical-binding: t -*-
+
+;; Copyright (c) 2025 Daniel Hennigar
+
+;; Permission is hereby granted, free of charge, to any person obtaining a copy
+;; of this software and associated documentation files (the "Software"), to deal
+;; in the Software without restriction, including without limitation the rights
+;; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+;; copies of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+
+;; The above copyright notice and this permission notice shall be included in all
+;; copies or substantial portions of the Software.
+
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+;; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+;; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+;;; Commentary:
+
+;; `flymake' syntax checker for perl using Perl::Critic.
+
+;;; Code:
+
+(require 'flymake)
+(require 'flymake-collection)
+
+(eval-when-compile
+  (require 'flymake-collection-define))
+
+(defcustom flymake-collection-perlcritic-args '()
+    "Command line arguments will be passed to `flymake-collection-perlcritic.'.
+
+See \"perlcritic --options\". Note that the \"--verbose\" flag is not
+currently supported and will be stripped for correct output parsing."
+    :type '(repeat :tag "Arguments" (string :tag "Argument"))
+    :group 'flymake-collection)
+
+(defcustom flymake-collection-perlcritic-severity 3
+    "Set the severity level (or \"harshness\") of `perlcritic`.
+
+Ranges from 1 (highest severity, most warnings)
+to 5 (lowest severity, least warnings)."
+    :type 'integer
+    :group 'flymake-collection)
+
+;;;###autoload (autoload 'flymake-collection-perlcritic "flymake-collection-perlcritic")
+(flymake-collection-define-rx flymake-collection-perlcritic
+  "This backend for `flymake' is based on Perl::Critic.
+
+Provides additional warnings and is intended to accompany perl-mode's
+default `perl-flymake', which uses the perl interpreter to catch syntax
+errors. Requires Perl::Critic to be installed.
+See URL `https://metacpan.org/pod/Perl::Critic'."
+  :title "perlcritic"
+  :pre-let ((perlcritic-exec (executable-find "perlcritic")))
+  :pre-check (unless perlcritic-exec
+               (user-error "Cannot find perlcritic executable"))
+  :write-type 'pipe
+  :command `(,perlcritic-exec
+             "--severity" ,(number-to-string flymake-collection-perlcritic-severity)
+             ;; enforce verbosity level 1 for correct regex matching
+             "--verbose" "1"
+             ,@(let ((args flymake-collection-perlcritic-args)
+                     (pos (member "--verbose" flymake-collection-perlcritic-args)))
+                   (if (and pos (string-match-p "^[0-9]+$" (cadr pos)))
+                           (remove (cadr pos) (remove "--verbose" args))
+                       (remove "--verbose" args)))
+             "-")
+  :regexps
+  ;; only notes since perlcritic mostly provides stylistic suggestions
+  ((note bol (file-name) ":" line ":" column ":" (message (+ nonl)) eol)))
+
+(provide 'flymake-collection-perlcritic)
+
+;;; flymake-collection-perlcritic.el ends here

--- a/tests/checkers/installers/perlcritic.bash
+++ b/tests/checkers/installers/perlcritic.bash
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e  # Exit on any error
+set -u  # Treat unset variables as errors
+
+# Ensure necessary tools are available
+echo "Updating package list..."
+sudo apt-get update -y
+
+echo "Installing Perl and cpanminus..."
+sudo apt-get install -y perl cpanminus
+
+echo "Installing Perl::Critic..."
+sudo cpanm --notest --quiet Perl::Critic
+
+# Verify installation
+if command -v perlcritic &>/dev/null; then
+    echo "Perl::Critic installed successfully."
+else
+    echo "Error: Perl::Critic installation failed."
+    exit 1
+fi

--- a/tests/checkers/test-cases/perlcritic.yml
+++ b/tests/checkers/test-cases/perlcritic.yml
@@ -1,0 +1,25 @@
+---
+checker: flymake-collection-perlcritic
+tests:
+  - name: no-lints
+    file: |
+      #!/bin/env perl
+      # A test case that returns no warnings
+
+      use warnings;
+      use strict;      
+      print 'hello world\n';
+    lints: []
+  - name: notes
+    file: |
+      #!/bin/env perl
+      # A test case with a warning lint
+
+      print 'hello world\n';
+    lints:
+      - point: [4, 0]
+        level: note
+        message: Code before warnings are enabled (perlcritic)
+      - point: [4, 0]
+        level: note
+        message: Code before strictures are enabled (perlcritic)


### PR DESCRIPTION
Perl::Critic is a static code analyzer for Perl which adheres to "Perl Best Practices" by Damian Conway. It offers warnings in order to enforce clean coding guidelines with configurable "severity", essentially a filter on which warnings the user wants to see.

This patch implements a simple back-end for perlcritic (Perl::Critic's command line interface) and exposes `flymake-collection-perlcritic-severity` to set "--severity" and `flymake-collection-perlcritic-args` for passing additional arguments to the linter.

Perl::Critic is NOT a general purpose linter for things like syntax errors. This back-end is best used in combination with the default back-end defined in (c)perl-mode.el, which relies on the Perl interpreter. Following the configuration instructions in the README already enables this behavior by default.