### PR TITLE
Correct erroneous ,@ in flymake-collection-vale.el

### DIFF
--- a/src/checkers/flymake-collection-vale.el
+++ b/src/checkers/flymake-collection-vale.el
@@ -73,9 +73,9 @@ See https://vale.sh/."
                (error "Cannot find vale executable"))
   :write-type 'pipe
   :command `(,vale-exec
-             ,@(when-let ((file-extension
-                           (funcall flymake-collection-vale-extension-function flymake-collection-source)))
-                 (concat "--ext=." file-extension))
+             ,(when-let ((file-extension
+                          (funcall flymake-collection-vale-extension-function flymake-collection-source)))
+                (concat "--ext=." file-extension))
              "--output=JSON")
   :generator
   (cdaar


### PR DESCRIPTION
This solves a bug wherein splicing causes the vale checker to fail, since a string is spliced rather than passed directly to the vale command.